### PR TITLE
replace tempfile command with mktemp

### DIFF
--- a/build-rootfs-img.sh
+++ b/build-rootfs-img.sh
@@ -45,7 +45,7 @@ if [ ${IMG_SIZE} -eq 0 ]; then
     ROOTFS_SIZE=`du -s -B 1 ${ROOTFS_DIR} | cut -f1`
     # +1024m + 10% rootfs size
     MAX_IMG_SIZE=$((${ROOTFS_SIZE} + 1024*1024*1024 + ${ROOTFS_SIZE}/5))
-    TMPFILE=`tempfile`
+    TMPFILE=`mktemp`
     ${MKFS} -s -l ${MAX_IMG_SIZE} -a root -L rootfs /dev/null ${ROOTFS_DIR} > ${TMPFILE}
     IMG_SIZE=`cat ${TMPFILE} | grep "Suggest size:" | cut -f2 -d ':' | awk '{gsub(/^\s+|\s+$/, "");print}'`
     rm -f ${TMPFILE}


### PR DESCRIPTION
tempfile is only present on debian-based systems.
we can use the mktemp command to allow the friendlywrt build command to execute successfully on both fedora and debian-based systems. 